### PR TITLE
Fix UAVCAN posix server usage for NuttX

### DIFF
--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -155,9 +155,9 @@ px4_add_module(
 		safety_state.cpp
 		safety_state.hpp
 
-		# Main
-		uavcan_main.cpp
-		uavcan_servers.cpp
+                # Main
+                uavcan_main.cpp
+                $<$<OR:$<STREQUAL:${PX4_PLATFORM},posix>,$<STREQUAL:${PX4_PLATFORM},ros2>>:uavcan_servers.cpp>
 
 		# Actuators
 		actuators/esc.cpp

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -126,10 +126,12 @@ UavcanNode::UavcanNode(uavcan::ICanDriver &can_driver, uavcan::ISystemClock &sys
 
 UavcanNode::~UavcanNode()
 {
-	if (_servers != nullptr) {
-		delete _servers;
-		_servers = nullptr;
-	}
+#if defined(__PX4_POSIX)
+       if (_servers != nullptr) {
+               delete _servers;
+               _servers = nullptr;
+       }
+#endif
 
 	if (_instance) {
 
@@ -623,17 +625,19 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	int32_t uavcan_enable = 1;
 	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
 
-	if (uavcan_enable > 1) {
-		_servers = new UavcanServers(_node, _node_info_retriever);
+       if (uavcan_enable > 1) {
+#if defined(__PX4_POSIX)
+               _servers = new UavcanServers(_node, _node_info_retriever);
 
-		if (_servers) {
-			int rv = _servers->init();
+               if (_servers) {
+                       int rv = _servers->init();
 
-			if (rv < 0) {
-				PX4_ERR("UavcanServers init: %d", rv);
-			}
-		}
-	}
+                       if (rv < 0) {
+                               PX4_ERR("UavcanServers init: %d", rv);
+                       }
+               }
+#endif
+       }
 
 	// Start the Node
 	return _node.start();

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -367,5 +367,7 @@ private:
 
 	bool _check_fw{false};
 
-	UavcanServers   *_servers{nullptr};
+#if defined(__PX4_POSIX)
+       UavcanServers   *_servers{nullptr};
+#endif
 };

--- a/src/drivers/uavcan/uavcan_servers.cpp
+++ b/src/drivers/uavcan/uavcan_servers.cpp
@@ -52,9 +52,13 @@
 #include "uavcan_main.hpp"
 #include "uavcan_servers.hpp"
 
+#if defined(__PX4_POSIX)
 #include <uavcan_posix/dynamic_node_id_server/file_event_tracer.hpp>
 #include <uavcan_posix/dynamic_node_id_server/file_storage_backend.hpp>
 #include <uavcan_posix/firmware_version_checker.hpp>
+#endif
+
+#if defined(__PX4_POSIX)
 
 /**
  * @file uavcan_servers.cpp
@@ -274,3 +278,4 @@ int UavcanServers::copyFw(const char *dst, const char *src)
 
 	return rv;
 }
+#endif

--- a/src/drivers/uavcan/uavcan_servers.hpp
+++ b/src/drivers/uavcan/uavcan_servers.hpp
@@ -40,10 +40,12 @@
 #include <uavcan/protocol/firmware_update_trigger.hpp>
 #include <uavcan/protocol/node_info_retriever.hpp>
 #include <uavcan/protocol/node_status_monitor.hpp>
+#if defined(__PX4_POSIX)
 #include <uavcan_posix/basic_file_server_backend.hpp>
 #include <uavcan_posix/dynamic_node_id_server/file_event_tracer.hpp>
 #include <uavcan_posix/dynamic_node_id_server/file_storage_backend.hpp>
 #include <uavcan_posix/firmware_version_checker.hpp>
+#endif
 
 #include "uavcan_module.hpp"
 
@@ -59,29 +61,39 @@
 /**
  * A UAVCAN Server Sub node.
  */
+#if defined(__PX4_POSIX)
 class UavcanServers
 {
 public:
-	UavcanServers(uavcan::INode &node, uavcan::NodeInfoRetriever &node_info_retriever);
-	~UavcanServers() = default;
+       UavcanServers(uavcan::INode &node, uavcan::NodeInfoRetriever &node_info_retriever);
+       ~UavcanServers() = default;
 
-	int init();
+       int init();
 
-	bool guessIfAllDynamicNodesAreAllocated() { return _server_instance.guessIfAllDynamicNodesAreAllocated(); }
+       bool guessIfAllDynamicNodesAreAllocated() { return _server_instance.guessIfAllDynamicNodesAreAllocated(); }
 
 private:
 
-	void unpackFwFromROMFS(const char *sd_path, const char *romfs_path);
-	void migrateFWFromRoot(const char *sd_path, const char *sd_root_path);
-	int copyFw(const char *dst, const char *src);
+       void unpackFwFromROMFS(const char *sd_path, const char *romfs_path);
+       void migrateFWFromRoot(const char *sd_path, const char *sd_root_path);
+       int copyFw(const char *dst, const char *src);
 
-	uavcan_posix::dynamic_node_id_server::FileEventTracer _tracer;
-	uavcan_posix::dynamic_node_id_server::FileStorageBackend _storage_backend;
-	uavcan_posix::FirmwareVersionChecker _fw_version_checker;
-	uavcan::dynamic_node_id_server::CentralizedServer _server_instance;  ///< server singleton pointer
-	uavcan_posix::BasicFileServerBackend _fileserver_backend;
-	uavcan::FirmwareUpdateTrigger _fw_upgrade_trigger;
-	uavcan::BasicFileServer _fw_server;
+       uavcan_posix::dynamic_node_id_server::FileEventTracer _tracer;
+       uavcan_posix::dynamic_node_id_server::FileStorageBackend _storage_backend;
+       uavcan_posix::FirmwareVersionChecker _fw_version_checker;
+       uavcan::dynamic_node_id_server::CentralizedServer _server_instance;  ///< server singleton pointer
+       uavcan_posix::BasicFileServerBackend _fileserver_backend;
+       uavcan::FirmwareUpdateTrigger _fw_upgrade_trigger;
+       uavcan::BasicFileServer _fw_server;
 
-	uavcan::NodeInfoRetriever &_node_info_retriever;
+       uavcan::NodeInfoRetriever &_node_info_retriever;
 };
+#else
+class UavcanServers
+{
+public:
+       UavcanServers(uavcan::INode &, uavcan::NodeInfoRetriever &) {}
+       int init() { return -1; }
+       bool guessIfAllDynamicNodesAreAllocated() { return false; }
+};
+#endif


### PR DESCRIPTION
## Summary
- restrict inclusion of UAVCAN posix server components to posix builds
- disable server creation on NuttX targets
- compile uavcan_servers only when building for posix or ros2

## Testing
- `make format` *(fails: astyle is not installed)*
- `make quick_check` *(fails: kconfiglib is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6846e8161364832da7782567641cb142